### PR TITLE
feat: mask API key in logs and improve config handling in linux

### DIFF
--- a/cmd/civitai-downloader/cmd/download.go
+++ b/cmd/civitai-downloader/cmd/download.go
@@ -114,6 +114,16 @@ func init() {
 var logLevel string
 var logFormat string
 
+func maskApiKey(key string) string {
+	if key == "" {
+		return "(not set)"
+	}
+	if len(key) <= 4 {
+		return "****" // shouldn't happen with valid keys
+	}
+	return "****" + key[len(key)-4:] // show last 4 chars
+}
+
 // setupDownloadEnvironment handles the initialization of database, downloaders, and concurrency settings.
 func setupDownloadEnvironment(cmd *cobra.Command, cfg *models.Config) (db *database.DB, fileDownloader *downloader.Downloader, imageDownloader *downloader.Downloader, concurrencyLevel int, err error) {
 	// --- Database Setup ---
@@ -298,6 +308,7 @@ func confirmParameters(queryParams models.QueryParameters) bool {
 		"SavePath":       viper.GetString("savepath"),
 		"DatabasePath":   viper.GetString("databasepath"),
 		"BleveIndexPath": viper.GetString("bleveindexpath"),
+		"ApiKey":         maskApiKey(viper.GetString("apikey")), // Show masked API key
 		// Filtering - Model/Version
 		"DownloadAllVersions": viper.GetBool("downloadallversions"),
 		"ModelVersionID":      viper.GetInt("modelversionid"),
@@ -453,6 +464,7 @@ func runDownload(cmd *cobra.Command, args []string) {
 			"SavePath":       viper.GetString("savepath"),
 			"DatabasePath":   viper.GetString("databasepath"),
 			"BleveIndexPath": viper.GetString("bleveindexpath"),
+			"ApiKey":         maskApiKey(viper.GetString("apikey")),
 			// Filtering - Model/Version
 			"DownloadAllVersions": viper.GetBool("downloadallversions"),
 			"ModelVersionID":      viper.GetInt("modelversionid"),

--- a/internal/downloader/downloader.go
+++ b/internal/downloader/downloader.go
@@ -159,6 +159,8 @@ func (d *Downloader) DownloadFile(targetFilepath string, url string, hashes mode
 	if err != nil {
 		return "", fmt.Errorf("%w: creating download request for %s: %w", ErrHttpRequest, url, err)
 	}
+	// Set browser-like user agent
+	req.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36")
 
 	// Add authentication header if API key is present
 	log.Debugf("Downloader stored API Key: %s", d.apiKey) // Added Debug Log


### PR DESCRIPTION
On linux, config was not read and ApiKey was not pulled. So it didn't work. This fixed it.

I added option to get key from os.env.

Not sure if it still runs fine on windows, see change line 72 in cmd/civitai-downloader/cmd/root.go

Now it works on my end.
Not sure why it didn't work. Tried Arch and Docker:Ubuntu.

Side note, more models are showing 0b size and hash errors... They are being deleted.