### PR TITLE
Add Session Based Auth and fix some response handling issues

### DIFF
--- a/cmd/civitai-downloader/cmd/cmd_download_api.go
+++ b/cmd/civitai-downloader/cmd/cmd_download_api.go
@@ -914,8 +914,8 @@ func CreateDownloadQueryParams(cfg *models.Config) models.QueryParameters {
 func fetchAndProcessModels(apiClient *api.Client, db *database.DB, queryParams models.QueryParameters, cfg *models.Config) ([]potentialDownload, error) {
 
 	// Setup image downloader (needed for all-versions case inside fetchModelsPaginated)
-	// Pass the correct arguments: http client and api key
-	imageDownloader := downloader.NewDownloader(apiClient.HttpClient, cfg.APIKey)
+	// Pass the correct arguments: http client, api key, and session cookie
+	imageDownloader := downloader.NewDownloader(apiClient.HttpClient, cfg.APIKey, cfg.SessionCookie)
 
 	// Fetch models - Pass userTotalLimit (cfg.Download.Limit) now
 	allPotentialDownloads, _, err := fetchModelsPaginated(apiClient, db, imageDownloader, queryParams, cfg, cfg.Download.Limit)

--- a/cmd/civitai-downloader/cmd/cmd_images_run.go
+++ b/cmd/civitai-downloader/cmd/cmd_images_run.go
@@ -139,7 +139,7 @@ func runImages(cmd *cobra.Command, args []string) {
 		Transport: globalHttpTransport,
 		Timeout:   0,
 	}
-	dl := downloader.NewDownloader(downloadHttpClient, cfg.APIKey)
+	dl := downloader.NewDownloader(downloadHttpClient, cfg.APIKey, cfg.SessionCookie)
 
 	finalBaseTargetDir := targetDir
 	log.Infof("Preparing to download images to base directory: %s", finalBaseTargetDir)

--- a/cmd/civitai-downloader/cmd/db.go
+++ b/cmd/civitai-downloader/cmd/db.go
@@ -436,7 +436,7 @@ func initializeDownloader() *downloader.Downloader {
 	}
 
 	log.Debug("Downloader initialized.")
-	return downloader.NewDownloader(httpClient, globalConfig.APIKey)
+	return downloader.NewDownloader(httpClient, globalConfig.APIKey, globalConfig.SessionCookie)
 }
 
 // performRedownload performs the actual redownload of a file
@@ -553,7 +553,7 @@ func runDbRedownload(cmd *cobra.Command, args []string) {
 	// TODO: Refactor client creation/sharing?
 	downloaderHttpClient := &http.Client{Timeout: 30 * time.Minute} // Longer timeout for downloads
 	// Use correct case for APIKey
-	fileDownloader := downloader.NewDownloader(downloaderHttpClient, globalConfig.APIKey)
+	fileDownloader := downloader.NewDownloader(downloaderHttpClient, globalConfig.APIKey, globalConfig.SessionCookie)
 
 	// Perform the download, checking the error
 	// Pass the Model Version ID from the database entry

--- a/cmd/civitai-downloader/cmd/download.go
+++ b/cmd/civitai-downloader/cmd/download.go
@@ -138,7 +138,7 @@ func setupDownloadEnvironment(cfg *models.Config) (db *database.DB, fileDownload
 		Timeout:   0, // Timeout should be handled by transport or context
 		Transport: globalHttpTransport,
 	}
-	fileDownloader = downloader.NewDownloader(mainHttpClient, cfg.APIKey)
+	fileDownloader = downloader.NewDownloader(mainHttpClient, cfg.APIKey, cfg.SessionCookie)
 
 	// --- Setup Image Downloader ---
 	if cfg.Download.SaveVersionImages || cfg.Download.SaveModelImages {
@@ -147,7 +147,7 @@ func setupDownloadEnvironment(cfg *models.Config) (db *database.DB, fileDownload
 			Timeout:   0,
 			Transport: globalHttpTransport,
 		}
-		imageDownloader = downloader.NewDownloader(imgHttpClient, cfg.APIKey)
+		imageDownloader = downloader.NewDownloader(imgHttpClient, cfg.APIKey, cfg.SessionCookie)
 	}
 	if imageDownloader != nil {
 		log.Debug("Image downloader initialized successfully.")

--- a/cmd/civitai-downloader/cmd/root.go
+++ b/cmd/civitai-downloader/cmd/root.go
@@ -31,6 +31,9 @@ var apiDelayFlag int
 // apiTimeoutFlag holds the value of the --api-timeout flag
 var apiTimeoutFlag int
 
+// sessionCookieFlag holds the browser session cookie for login-required downloads
+var sessionCookieFlag string
+
 // logLevelFlagValue holds the value of the --log-level flag, bound by Cobra
 var logLevelFlagValue string
 
@@ -70,6 +73,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&savePathFlag, "save-path", "", "Directory to save models (overrides config)")                                        // Default empty string
 	rootCmd.PersistentFlags().IntVar(&apiDelayFlag, "api-delay", -1, "Delay between API calls in ms (overrides config, -1 uses config default)")              // Default -1
 	rootCmd.PersistentFlags().IntVar(&apiTimeoutFlag, "api-timeout", -1, "Timeout for API HTTP client in seconds (overrides config, -1 uses config default)") // Default -1
+	rootCmd.PersistentFlags().StringVar(&sessionCookieFlag, "session-cookie", "", "Browser session cookie for login-required downloads (overrides config)")
 
 	// Removed viper.BindPFlag calls
 	// Removed viper.SetDefault calls
@@ -372,6 +376,13 @@ func applyPersistentFlags(cmd *cobra.Command, flags *config.CliFlags) {
 		flags.APIClientTimeoutSec = &apiTimeoutFlag
 	} else {
 		log.Debugf("[loadGlobalConfig] --api-timeout flag not detected or is default -1.")
+	}
+
+	if sessionCookieFlag != "" {
+		log.Debugf("[loadGlobalConfig] --session-cookie flag detected")
+		flags.SessionCookie = &sessionCookieFlag
+	} else {
+		log.Debugf("[loadGlobalConfig] --session-cookie flag not detected or is empty.")
 	}
 }
 

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -26,6 +26,9 @@ var (
 
 const CivitaiApiBaseUrl = "https://civitai.com/api/v1"
 
+// UserAgent is the browser User-Agent string used for HTTP requests to avoid 401 errors
+const UserAgent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
+
 // Client struct for interacting with the Civitai API
 type Client struct {
 	// Pointer first
@@ -141,6 +144,7 @@ func (c *Client) GetModels(cursor string, queryParams models.QueryParameters) (s
 	}
 
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", UserAgent)
 	if c.ApiKey != "" {
 		req.Header.Set("Authorization", "Bearer "+c.ApiKey)
 	}
@@ -212,6 +216,7 @@ func (c *Client) GetModelDetails(modelID int) (models.Model, error) {
 	}
 
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", UserAgent)
 	if c.ApiKey != "" {
 		req.Header.Set("Authorization", "Bearer "+c.ApiKey)
 	}
@@ -249,6 +254,7 @@ func (c *Client) GetModelVersionDetails(versionID int) (models.ModelVersion, err
 	}
 
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", UserAgent)
 	if c.ApiKey != "" {
 		req.Header.Set("Authorization", "Bearer "+c.ApiKey)
 	}
@@ -289,6 +295,7 @@ func (c *Client) GetImages(cursor string, queryParams models.ImageAPIParameters)
 	}
 
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", UserAgent)
 	if c.ApiKey != "" {
 		req.Header.Set("Authorization", "Bearer "+c.ApiKey)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -188,6 +188,7 @@ type CliFlags struct {
 	APIDelayMs          *int    // --api-delay
 	APIClientTimeoutSec *int    // --api-timeout
 	APIKey              *string // --api-key (download command, but promote to global?)
+	SessionCookie       *string // --session-cookie (for login-required downloads)
 	// Flags for potentially new config options:
 	MaxRetries          *int // Needs new flag e.g. --max-retries
 	InitialRetryDelayMs *int // Needs new flag e.g. --retry-delay
@@ -419,6 +420,10 @@ func applyGlobalFlags(cfg *models.Config, flags CliFlags) {
 	if flags.APIKey != nil {
 		log.Debugf("[Initialize] Overriding APIKey from flag.")
 		cfg.APIKey = *flags.APIKey
+	}
+	if flags.SessionCookie != nil {
+		log.Debugf("[Initialize] Overriding SessionCookie from flag.")
+		cfg.SessionCookie = *flags.SessionCookie
 	}
 	if flags.SavePath != nil {
 		log.Debugf("[Initialize] Overriding SavePath from flag: '%s'", *flags.SavePath)


### PR DESCRIPTION
Session based authentication allows a user to login via the browser copy their cookie and then proceed to download as if they were actually logged in; this is necessary for some models that have elected that a user must be logged in order to download.

Also fixed some response body handling.