### PR TITLE
feat: add --ignore-tags option (based on #28 by @Xgame-ctrl)

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Generally arguments passed into the application will override the config file se
 | `ModelTypes`            | `[]string` | `[]`                 | Default model types to query (e.g., `["Checkpoint", "LORA"]`). Empty means all types.                |
 | `BaseModels`            | `[]string` | `[]`                 | Default base models to query (e.g., `["SDXL 1.0"]`). Empty means all base models.                     |
 | `IgnoreBaseModels`      | `[]string` | `[]`                 | List of base model strings to ignore (case-insensitive substring match). (`--ignore-base-models` flag) |
+| `IgnoreTags`            | `[]string` | `[]`                 | List of tags to ignore (exact match, case-insensitive). (`--ignore-tags` flag) |
 | `Nsfw`                  | `bool`     | `false`              | Default setting for including NSFW models in API queries.                                               |
 | `ModelVersionID`        | `int`      | `0`                  | Default model version ID to download (0 = disabled, overrides other filters).                           |
 | `AllVersions`           | `bool`     | `false`              | Download all versions of matched models, not just the latest. (`--all-versions` flag)                   |
@@ -223,6 +224,7 @@ Scans the Civitai API based on filters, asks for confirmation, and then download
 *   `--pruned`: Only download pruned Checkpoints (overrides config `Pruned`).
 *   `--fp16`: Only download fp16 Checkpoints (overrides config `Fp16`).
 *   `--ignore-base-models strings`: Base models to ignore (comma-separated or multiple flags, overrides config `IgnoreBaseModels`). *(No shorthand)*
+*   `--ignore-tags strings`: Tags to ignore (comma-separated or multiple flags, overrides config `IgnoreTags`). *(No shorthand)*
 *   `--ignore-filename-strings strings`: Substrings in filenames to ignore (comma-separated or multiple flags, overrides config `IgnoreFileNameStrings`). *(No shorthand)*
 *   `-c, --concurrency int`: Number of concurrent downloads (overrides config `Concurrency`).
 *   `--max-pages int`: Maximum number of API pages to fetch (0 for no limit). *(No shorthand)*

--- a/cmd/civitai-downloader/cmd/cmd_download_api.go
+++ b/cmd/civitai-downloader/cmd/cmd_download_api.go
@@ -243,6 +243,20 @@ func handleSingleVersionDownload(versionID int, db *database.DB, apiClient *api.
 	log.Infof("Successfully fetched details for version %d (%s) of model %s (%s)",
 		versionResponse.ID, versionResponse.Name, versionResponse.Model.Name, versionResponse.Model.Type)
 
+	var fullModelDetails models.Model
+    if len(cfg.Download.IgnoreTags) > 0 {
+        log.Debugf("IgnoreTags specified, fetching full model details for tag check...")
+        var err error
+        fullModelDetails, err = apiClient.GetModelDetails(versionResponse.ModelId)
+        if err != nil {
+            log.WithError(err).Warnf("Failed to fetch model details for tag check. Proceeding without tag filtering.")
+        } else {
+            log.Debugf("Successfully fetched model details for tag check. Model has %d tags.", len(fullModelDetails.Tags))
+        }
+    } else {
+        fullModelDetails.Tags = []string{}
+    }
+
 	if !passesBaseModelsFilter(versionResponse, cfg) {
 		return make([]potentialDownload, 0), 0, nil
 	}
@@ -258,6 +272,7 @@ func handleSingleVersionDownload(versionID int, db *database.DB, apiClient *api.
 		ID:   versionResponse.ModelId, // Use ModelId from version
 		Name: versionResponse.Model.Name,
 		Type: versionResponse.Model.Type,
+		Tags: fullModelDetails.Tags,
 		// Creator is missing here, buildPathData will use fallback
 	}
 
@@ -283,6 +298,7 @@ func handleSingleVersionDownload(versionID int, db *database.DB, apiClient *api.
 			ModelName:         pseudoModel.Name,
 			ModelType:         pseudoModel.Type,
 			Creator:           pseudoModel.Creator, // Will be fallback "unknown_creator"
+			Tags:              fullModelDetails.Tags,
 			FullVersion:       versionWithoutFilesImages,
 			ModelVersionID:    versionResponse.ID,
 			File:              file,
@@ -442,6 +458,7 @@ func handleSingleModelDownload(modelID int, db *database.DB, apiClient *api.Clie
 				ModelName:         modelResponse.Name,
 				ModelType:         modelResponse.Type,
 				Creator:           modelResponse.Creator,
+				Tags:              modelResponse.Tags,
 				FullVersion:       versionForPd,
 				ModelVersionID:    versionForPd.ID,
 				File:              file,
@@ -595,6 +612,26 @@ func filterAndPrepareDownloads(potentialDownloadsPage []potentialDownload, db *d
 			continue
 		}
 
+		ignoredTags := cfg.Download.IgnoreTags
+        tagMatch := false
+        if len(ignoredTags) > 0 && len(pd.Tags) > 0 {
+            for _, ignoredTag := range ignoredTags {
+                for _, modelTag := range pd.Tags {
+                    if strings.EqualFold(ignoredTag, modelTag) {
+                        log.Debugf("      - Skipping file %s (Version %d): Model has ignored tag '%s'.", pd.File.Name, pd.ModelVersionID, ignoredTag)
+                        tagMatch = true
+                        break
+                    }
+                }
+                if tagMatch {
+                    break
+                }
+            }
+        }
+        if tagMatch {
+            continue
+        }
+
 		downloadsToQueueFiltered = append(downloadsToQueueFiltered, pd)
 		totalSizeFiltered += uint64(pd.File.SizeKB) * 1024
 	}
@@ -729,6 +766,10 @@ func processModelsOnPage(models []models.Model, apiClient *api.Client, cfg *mode
 			continue
 		}
 
+        if shouldSkipModelForTags(model, cfg) {
+            continue
+        }
+
 		fullModelDetails, err := fetchFullModelDetails(model.ID, apiClient)
 		if err != nil {
 			continue
@@ -806,6 +847,24 @@ func passesBaseModelsFilter(version models.ModelVersion, cfg *models.Config) boo
 	return false
 }
 
+// shouldSkipModelForTags checks if a model should be skipped based on tag filters
+func shouldSkipModelForTags(model models.Model, cfg *models.Config) bool {
+    if len(cfg.Download.IgnoreTags) == 0 || len(model.Tags) == 0 {
+        return false
+    }
+
+	for _, ignoredTag := range cfg.Download.IgnoreTags {
+        for _, modelTag := range model.Tags {
+            if strings.EqualFold(ignoredTag, modelTag) {
+                log.Debugf("Skipping model %s (ID: %d) due to ignored tag: '%s'", model.Name, model.ID, ignoredTag)
+                return true
+            }
+        }
+    }
+
+    return false
+}
+
 // fetchFullModelDetails fetches complete model details from the API
 func fetchFullModelDetails(modelID int, apiClient *api.Client) (models.Model, error) {
 	log.Debugf("Fetching full details for model %d to ensure accurate version data...", modelID)
@@ -869,6 +928,7 @@ func processVersionFiles(fullModelDetails models.Model, version models.ModelVers
 			ModelName:      fullModelDetails.Name,
 			ModelType:      fullModelDetails.Type,
 			Creator:        fullModelDetails.Creator,
+			Tags:           fullModelDetails.Tags,
 			FullVersion:    versionForPd,
 			ModelVersionID: versionForPd.ID,
 			File:           file,

--- a/cmd/civitai-downloader/cmd/cmd_download_api.go
+++ b/cmd/civitai-downloader/cmd/cmd_download_api.go
@@ -243,19 +243,19 @@ func handleSingleVersionDownload(versionID int, db *database.DB, apiClient *api.
 	log.Infof("Successfully fetched details for version %d (%s) of model %s (%s)",
 		versionResponse.ID, versionResponse.Name, versionResponse.Model.Name, versionResponse.Model.Type)
 
-	var fullModelDetails models.Model
-    if len(cfg.Download.IgnoreTags) > 0 {
-        log.Debugf("IgnoreTags specified, fetching full model details for tag check...")
-        var err error
-        fullModelDetails, err = apiClient.GetModelDetails(versionResponse.ModelId)
-        if err != nil {
-            log.WithError(err).Warnf("Failed to fetch model details for tag check. Proceeding without tag filtering.")
-        } else {
-            log.Debugf("Successfully fetched model details for tag check. Model has %d tags.", len(fullModelDetails.Tags))
-        }
-    } else {
-        fullModelDetails.Tags = []string{}
-    }
+	// Check tags before proceeding — requires fetching parent model details.
+	if len(cfg.Download.IgnoreTags) > 0 {
+		log.Debugf("IgnoreTags specified, fetching full model details for tag check...")
+		fullModelDetails, err := apiClient.GetModelDetails(versionResponse.ModelId)
+		if err != nil {
+			log.WithError(err).Warnf("Failed to fetch model details for tag check. Proceeding without tag filtering.")
+		} else {
+			log.Debugf("Successfully fetched model details for tag check. Model has %d tags.", len(fullModelDetails.Tags))
+			if shouldSkipModelForTags(fullModelDetails, cfg) {
+				return make([]potentialDownload, 0), 0, nil
+			}
+		}
+	}
 
 	if !passesBaseModelsFilter(versionResponse, cfg) {
 		return make([]potentialDownload, 0), 0, nil
@@ -272,7 +272,6 @@ func handleSingleVersionDownload(versionID int, db *database.DB, apiClient *api.
 		ID:   versionResponse.ModelId, // Use ModelId from version
 		Name: versionResponse.Model.Name,
 		Type: versionResponse.Model.Type,
-		Tags: fullModelDetails.Tags,
 		// Creator is missing here, buildPathData will use fallback
 	}
 
@@ -298,11 +297,10 @@ func handleSingleVersionDownload(versionID int, db *database.DB, apiClient *api.
 			ModelName:         pseudoModel.Name,
 			ModelType:         pseudoModel.Type,
 			Creator:           pseudoModel.Creator, // Will be fallback "unknown_creator"
-			Tags:              fullModelDetails.Tags,
 			FullVersion:       versionWithoutFilesImages,
 			ModelVersionID:    versionResponse.ID,
 			File:              file,
-			TargetFilepath:    targetPath, // Use calculated full path
+			TargetFilepath:    targetPath,
 			FinalBaseFilename: finalBaseFilename,
 			OriginalImages:    versionResponse.Images,
 			BaseModel:         versionResponse.BaseModel,
@@ -353,6 +351,11 @@ func handleSingleModelDownload(modelID int, db *database.DB, apiClient *api.Clie
 
 	log.Infof("Successfully fetched details for model %s (ID: %d, Type: %s, Creator: %s)",
 		modelResponse.Name, modelResponse.ID, modelResponse.Type, modelResponse.Creator.Username)
+
+	// Check if model should be skipped based on tag filters
+	if shouldSkipModelForTags(modelResponse, cfg) {
+		return make([]potentialDownload, 0), 0, nil
+	}
 
 	// --- Model Images Processing --- START ---
 	if cfg.Download.SaveModelImages && imageDownloader != nil {
@@ -458,7 +461,6 @@ func handleSingleModelDownload(modelID int, db *database.DB, apiClient *api.Clie
 				ModelName:         modelResponse.Name,
 				ModelType:         modelResponse.Type,
 				Creator:           modelResponse.Creator,
-				Tags:              modelResponse.Tags,
 				FullVersion:       versionForPd,
 				ModelVersionID:    versionForPd.ID,
 				File:              file,
@@ -612,26 +614,6 @@ func filterAndPrepareDownloads(potentialDownloadsPage []potentialDownload, db *d
 			continue
 		}
 
-		ignoredTags := cfg.Download.IgnoreTags
-        tagMatch := false
-        if len(ignoredTags) > 0 && len(pd.Tags) > 0 {
-            for _, ignoredTag := range ignoredTags {
-                for _, modelTag := range pd.Tags {
-                    if strings.EqualFold(ignoredTag, modelTag) {
-                        log.Debugf("      - Skipping file %s (Version %d): Model has ignored tag '%s'.", pd.File.Name, pd.ModelVersionID, ignoredTag)
-                        tagMatch = true
-                        break
-                    }
-                }
-                if tagMatch {
-                    break
-                }
-            }
-        }
-        if tagMatch {
-            continue
-        }
-
 		downloadsToQueueFiltered = append(downloadsToQueueFiltered, pd)
 		totalSizeFiltered += uint64(pd.File.SizeKB) * 1024
 	}
@@ -766,9 +748,9 @@ func processModelsOnPage(models []models.Model, apiClient *api.Client, cfg *mode
 			continue
 		}
 
-        if shouldSkipModelForTags(model, cfg) {
-            continue
-        }
+		if shouldSkipModelForTags(model, cfg) {
+			continue
+		}
 
 		fullModelDetails, err := fetchFullModelDetails(model.ID, apiClient)
 		if err != nil {
@@ -847,22 +829,24 @@ func passesBaseModelsFilter(version models.ModelVersion, cfg *models.Config) boo
 	return false
 }
 
-// shouldSkipModelForTags checks if a model should be skipped based on tag filters
+// shouldSkipModelForTags checks if a model should be skipped based on tag filters.
+// Uses exact case-insensitive matching via helpers.StringSliceContains.
 func shouldSkipModelForTags(model models.Model, cfg *models.Config) bool {
-    if len(cfg.Download.IgnoreTags) == 0 || len(model.Tags) == 0 {
-        return false
-    }
+	if len(cfg.Download.IgnoreTags) == 0 || len(model.Tags) == 0 {
+		return false
+	}
 
 	for _, ignoredTag := range cfg.Download.IgnoreTags {
-        for _, modelTag := range model.Tags {
-            if strings.EqualFold(ignoredTag, modelTag) {
-                log.Debugf("Skipping model %s (ID: %d) due to ignored tag: '%s'", model.Name, model.ID, ignoredTag)
-                return true
-            }
-        }
-    }
+		if ignoredTag == "" {
+			continue
+		}
+		if helpers.StringSliceContains(model.Tags, ignoredTag) {
+			log.Debugf("Skipping model %s (ID: %d) due to ignored tag: '%s'", model.Name, model.ID, ignoredTag)
+			return true
+		}
+	}
 
-    return false
+	return false
 }
 
 // fetchFullModelDetails fetches complete model details from the API
@@ -928,7 +912,6 @@ func processVersionFiles(fullModelDetails models.Model, version models.ModelVers
 			ModelName:      fullModelDetails.Name,
 			ModelType:      fullModelDetails.Type,
 			Creator:        fullModelDetails.Creator,
-			Tags:           fullModelDetails.Tags,
 			FullVersion:    versionForPd,
 			ModelVersionID: versionForPd.ID,
 			File:           file,

--- a/cmd/civitai-downloader/cmd/cmd_download_api_test.go
+++ b/cmd/civitai-downloader/cmd/cmd_download_api_test.go
@@ -71,3 +71,93 @@ func TestPassesBaseModelsFilter(t *testing.T) {
 		})
 	}
 }
+
+func TestShouldSkipModelForTags(t *testing.T) {
+	tests := []struct {
+		name       string
+		model      models.Model
+		ignoreTags []string
+		want       bool
+	}{
+		{
+			name:       "no ignore tags configured - never skip",
+			model:      models.Model{ID: 1, Name: "TestModel", Tags: []string{"anime", "style"}},
+			ignoreTags: []string{},
+			want:       false,
+		},
+		{
+			name:       "model has no tags - never skip",
+			model:      models.Model{ID: 1, Name: "TestModel", Tags: []string{}},
+			ignoreTags: []string{"anime"},
+			want:       false,
+		},
+		{
+			name:       "model has nil tags - never skip",
+			model:      models.Model{ID: 1, Name: "TestModel"},
+			ignoreTags: []string{"anime"},
+			want:       false,
+		},
+		{
+			name:       "exact match - skip",
+			model:      models.Model{ID: 1, Name: "TestModel", Tags: []string{"anime", "style"}},
+			ignoreTags: []string{"anime"},
+			want:       true,
+		},
+		{
+			name:       "case-insensitive match - skip",
+			model:      models.Model{ID: 1, Name: "TestModel", Tags: []string{"Anime", "Style"}},
+			ignoreTags: []string{"anime"},
+			want:       true,
+		},
+		{
+			name:       "no matching tags - do not skip",
+			model:      models.Model{ID: 1, Name: "TestModel", Tags: []string{"photorealistic", "portrait"}},
+			ignoreTags: []string{"anime"},
+			want:       false,
+		},
+		{
+			name:       "matches one of multiple ignore tags - skip",
+			model:      models.Model{ID: 1, Name: "TestModel", Tags: []string{"anime", "style"}},
+			ignoreTags: []string{"nsfw", "anime", "deprecated"},
+			want:       true,
+		},
+		{
+			name:       "matches one of multiple model tags - skip",
+			model:      models.Model{ID: 1, Name: "TestModel", Tags: []string{"photorealistic", "nsfw", "portrait"}},
+			ignoreTags: []string{"nsfw"},
+			want:       true,
+		},
+		{
+			name:       "no match in multiple tags vs multiple ignores - do not skip",
+			model:      models.Model{ID: 1, Name: "TestModel", Tags: []string{"photorealistic", "portrait", "landscape"}},
+			ignoreTags: []string{"anime", "nsfw", "deprecated"},
+			want:       false,
+		},
+		{
+			name:       "empty string in ignore tags is ignored",
+			model:      models.Model{ID: 1, Name: "TestModel", Tags: []string{"anime"}},
+			ignoreTags: []string{""},
+			want:       false,
+		},
+		{
+			name:       "both empty - do not skip",
+			model:      models.Model{ID: 1, Name: "TestModel", Tags: []string{}},
+			ignoreTags: []string{},
+			want:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := models.Config{
+				Download: models.DownloadConfig{
+					IgnoreTags: tt.ignoreTags,
+				},
+			}
+			got := shouldSkipModelForTags(tt.model, &cfg)
+			if got != tt.want {
+				t.Errorf("shouldSkipModelForTags() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/civitai-downloader/cmd/cmd_download_types.go
+++ b/cmd/civitai-downloader/cmd/cmd_download_types.go
@@ -14,7 +14,6 @@ type potentialDownload struct {
 	VersionName       string // Name of the model version
 	// Slices
 	OriginalImages []models.ModelImage // Images associated with this version
-	Tags           []string            // Tags for filtering
 	// Large structs
 	FullModel      models.Model        // Added: Full model details (used for Model Images)
 	FullVersion    models.ModelVersion // Full details of this specific version

--- a/cmd/civitai-downloader/cmd/cmd_download_types.go
+++ b/cmd/civitai-downloader/cmd/cmd_download_types.go
@@ -14,6 +14,7 @@ type potentialDownload struct {
 	VersionName       string // Name of the model version
 	// Slices
 	OriginalImages []models.ModelImage // Images associated with this version
+	Tags           []string            // Tags for filtering
 	// Large structs
 	FullModel      models.Model        // Added: Full model details (used for Model Images)
 	FullVersion    models.ModelVersion // Full details of this specific version

--- a/cmd/civitai-downloader/cmd/debug.go
+++ b/cmd/civitai-downloader/cmd/debug.go
@@ -137,6 +137,7 @@ func addDownloadFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVarP(&downloadAllVersionsFlag, "all-versions", "a", false, "Download all versions of a model (requires --model-id)")
 	cmd.Flags().StringSliceVar(&downloadIgnoreBaseModelsFlag, "ignore-base-models", []string{}, "Base models to ignore (Client Filter, comma-separated or multiple flags)")
 	cmd.Flags().StringSliceVar(&downloadIgnoreFileNameStringsFlag, "ignore-filename-strings", []string{}, "Substrings in filenames to ignore (Client Filter, comma-separated or multiple flags)")
+	cmd.Flags().StringSliceVar(&downloadIgnoreTagsFlag, "ignore-tags", []string{}, "Tags to ignore (Client Filter, comma-separated or multiple flags)")
 	cmd.Flags().BoolVarP(&downloadYesFlag, "yes", "y", false, "Skip confirmation prompts")
 	cmd.Flags().BoolVar(&downloadMetadataFlag, "metadata", false, "Save model metadata file")
 	cmd.Flags().BoolVar(&downloadModelInfoFlag, "model-info", false, "Save full model info file")

--- a/cmd/civitai-downloader/cmd/download.go
+++ b/cmd/civitai-downloader/cmd/download.go
@@ -42,6 +42,7 @@ var (
 	downloadAllVersionsFlag           bool
 	downloadIgnoreBaseModelsFlag      []string
 	downloadIgnoreFileNameStringsFlag []string
+	downloadIgnoreTagsFlag            []string
 	downloadYesFlag                   bool // Corresponds to SkipConfirmation
 	downloadMetadataFlag              bool // Corresponds to SaveMetadata
 	downloadModelInfoFlag             bool // Corresponds to SaveModelInfo
@@ -88,6 +89,7 @@ func init() {
 	downloadCmd.Flags().BoolVar(&downloadAllVersionsFlag, "all-versions", false, "Download all versions of a model, not just the latest (overrides config)")
 	downloadCmd.Flags().StringSliceVar(&downloadIgnoreBaseModelsFlag, "ignore-base-models", []string{}, "Base models to ignore (comma-separated or multiple flags, overrides config)")
 	downloadCmd.Flags().StringSliceVar(&downloadIgnoreFileNameStringsFlag, "ignore-filename-strings", []string{}, "Substrings in filenames to ignore (comma-separated or multiple flags, overrides config)")
+	downloadCmd.Flags().StringSliceVar(&downloadIgnoreTagsFlag, "ignore-tags", []string{}, "Tags to ignore (comma-separated or multiple flags, overrides config)")
 
 	// Saving & Behavior
 	downloadCmd.Flags().BoolVarP(&downloadYesFlag, "yes", "y", false, "Skip confirmation prompt before downloading (overrides config)")
@@ -331,6 +333,7 @@ func confirmParameters(cmd *cobra.Command, cfg *models.Config, queryParams model
 		"Fp16":                  cfg.Download.Fp16,
 		"IgnoreBaseModels":      cfg.Download.IgnoreBaseModels,
 		"IgnoreFileNameStrings": cfg.Download.IgnoreFileNameStrings,
+		"IgnoreTags":            cfg.Download.IgnoreTags,
 		"InitialRetryDelayMs":   cfg.InitialRetryDelayMs,
 		"LogApiRequests":        cfg.LogApiRequests,
 		"LogFormat":             cfg.LogFormat,

--- a/cmd/civitai-downloader/cmd/root.go
+++ b/cmd/civitai-downloader/cmd/root.go
@@ -146,6 +146,9 @@ func applyDownloadFlags(cmd *cobra.Command, flags *config.CliFlags) {
 	if cmd.Flags().Changed("ignore-filename-strings") {
 		flags.Download.IgnoreFileNameStrings = &downloadIgnoreFileNameStringsFlag
 	}
+	if cmd.Flags().Changed("ignore-tags") {
+        flags.Download.IgnoreTags = &downloadIgnoreTagsFlag
+    }
 	if cmd.Flags().Changed("yes") {
 		flags.Download.SkipConfirmation = &downloadYesFlag
 	}
@@ -287,6 +290,9 @@ func applyDownloadFlagsFromGlobals(flags *config.CliFlags) {
 	if len(downloadIgnoreFileNameStringsFlag) > 0 {
 		flags.Download.IgnoreFileNameStrings = &downloadIgnoreFileNameStringsFlag
 	}
+    if len(downloadIgnoreTagsFlag) > 0 {
+        flags.Download.IgnoreTags = &downloadIgnoreTagsFlag
+    }
 	if downloadYesFlag {
 		flags.Download.SkipConfirmation = &downloadYesFlag
 	}

--- a/cmd/civitai-downloader/cmd/root.go
+++ b/cmd/civitai-downloader/cmd/root.go
@@ -147,8 +147,8 @@ func applyDownloadFlags(cmd *cobra.Command, flags *config.CliFlags) {
 		flags.Download.IgnoreFileNameStrings = &downloadIgnoreFileNameStringsFlag
 	}
 	if cmd.Flags().Changed("ignore-tags") {
-        flags.Download.IgnoreTags = &downloadIgnoreTagsFlag
-    }
+		flags.Download.IgnoreTags = &downloadIgnoreTagsFlag
+	}
 	if cmd.Flags().Changed("yes") {
 		flags.Download.SkipConfirmation = &downloadYesFlag
 	}
@@ -290,9 +290,9 @@ func applyDownloadFlagsFromGlobals(flags *config.CliFlags) {
 	if len(downloadIgnoreFileNameStringsFlag) > 0 {
 		flags.Download.IgnoreFileNameStrings = &downloadIgnoreFileNameStringsFlag
 	}
-    if len(downloadIgnoreTagsFlag) > 0 {
-        flags.Download.IgnoreTags = &downloadIgnoreTagsFlag
-    }
+	if len(downloadIgnoreTagsFlag) > 0 {
+		flags.Download.IgnoreTags = &downloadIgnoreTagsFlag
+	}
 	if downloadYesFlag {
 		flags.Download.SkipConfirmation = &downloadYesFlag
 	}

--- a/config.toml.example
+++ b/config.toml.example
@@ -75,6 +75,8 @@ Pruned = false
 Fp16 = false
 # List of case-insensitive strings. If a filename contains any of these, it will be ignored. Corresponds to --ignore-filename-strings flag.
 IgnoreFileNameStrings = []
+# List of tags to ignore (exact match, case-insensitive). Models with any of these tags will be skipped. Corresponds to --ignore-tags flag.
+IgnoreTags = []
 
 # --- API Query Behavior ---
 # Sorting order for model search results ("Highest Rated", "Most Downloaded", "Newest", etc.). Corresponds to --sort flag.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -559,10 +559,10 @@ func applyDownloadFlags(cfg *models.Config, flags CliFlags) {
 		cfg.Download.IgnoreFileNameStrings = *flags.Download.IgnoreFileNameStrings
 		log.Debugf("[Initialize] CLI Override: Download.IgnoreFileNameStrings = %v", cfg.Download.IgnoreFileNameStrings)
 	}
-    if flags.Download.IgnoreTags != nil {
-        cfg.Download.IgnoreTags = *flags.Download.IgnoreTags
-        log.Debugf("[Initialize] CLI Override: Download.IgnoreTags = %v", cfg.Download.IgnoreTags)
-    }
+	if flags.Download.IgnoreTags != nil {
+		cfg.Download.IgnoreTags = *flags.Download.IgnoreTags
+		log.Debugf("[Initialize] CLI Override: Download.IgnoreTags = %v", cfg.Download.IgnoreTags)
+	}
 	if flags.Download.SkipConfirmation != nil {
 		cfg.Download.SkipConfirmation = *flags.Download.SkipConfirmation
 		log.Debugf("[Initialize] CLI Override: Download.SkipConfirmation = %t", cfg.Download.SkipConfirmation)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -131,6 +131,7 @@ func setViperDefaults(v *viper.Viper) {
 	v.SetDefault("download.allversions", DefaultConfigDownloadAllVersions)
 	v.SetDefault("download.ignorebasemodels", []string{})      // Default empty slice
 	v.SetDefault("download.ignorefilenamestrings", []string{}) // Default empty slice
+	v.SetDefault("download.ignoretags", []string{})            // Default empty slice
 	v.SetDefault("download.skipconfirmation", DefaultConfigDownloadSkipConfirmation)
 	v.SetDefault("download.savemetadata", DefaultConfigDownloadSaveMetadata)
 	v.SetDefault("download.savemodelinfo", DefaultConfigDownloadSaveModelInfo)
@@ -227,6 +228,7 @@ type CliDownloadFlags struct {
 	AllVersions           *bool     // --all-versions
 	IgnoreBaseModels      *[]string // --ignore-base-models
 	IgnoreFileNameStrings *[]string // --ignore-filename-strings
+	IgnoreTags            *[]string // --ignore-tags
 	SkipConfirmation      *bool     // --yes
 	SaveMetadata          *bool     // --metadata
 	SaveModelInfo         *bool     // --model-info
@@ -306,6 +308,7 @@ func initializeDefaults() models.Config {
 			Usernames:             []string{},
 			IgnoreBaseModels:      []string{},
 			IgnoreFileNameStrings: []string{},
+			IgnoreTags:            []string{},
 		},
 		Images: models.ImagesConfig{
 			Limit:               100,
@@ -556,6 +559,10 @@ func applyDownloadFlags(cfg *models.Config, flags CliFlags) {
 		cfg.Download.IgnoreFileNameStrings = *flags.Download.IgnoreFileNameStrings
 		log.Debugf("[Initialize] CLI Override: Download.IgnoreFileNameStrings = %v", cfg.Download.IgnoreFileNameStrings)
 	}
+    if flags.Download.IgnoreTags != nil {
+        cfg.Download.IgnoreTags = *flags.Download.IgnoreTags
+        log.Debugf("[Initialize] CLI Override: Download.IgnoreTags = %v", cfg.Download.IgnoreTags)
+    }
 	if flags.Download.SkipConfirmation != nil {
 		cfg.Download.SkipConfirmation = *flags.Download.SkipConfirmation
 		log.Debugf("[Initialize] CLI Override: Download.SkipConfirmation = %t", cfg.Download.SkipConfirmation)

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -159,6 +159,7 @@ type (
 		Usernames             []string `toml:"Usernames"`
 		IgnoreBaseModels      []string `toml:"IgnoreBaseModels"`
 		IgnoreFileNameStrings []string `toml:"IgnoreFileNameStrings"`
+		IgnoreTags            []string `toml:"IgnoreTags"`
 		// Integers
 		Concurrency    int `toml:"Concurrency"`
 		Limit          int `toml:"Limit"`


### PR DESCRIPTION
## Summary

Adds `--ignore-tags` flag to skip models matching specified tags during download. Based on PR #28 by @Xgame-ctrl, with architectural improvements.

Closes #28

## What's New

- `--ignore-tags` CLI flag (comma-separated or multiple flags, overrides config)
- `IgnoreTags` config option in `config.toml`
- Case-insensitive exact match filtering via `helpers.StringSliceContains`
- Tag filtering at the **model level** — models with ignored tags are skipped before fetching full details

## Changes vs Original PR #28

| Aspect | PR #28 Original | This Version |
|--------|-----------------|--------------|
| Tag filtering scope | Model-level + file-level | **Model-level only** (tags are a `Model` attribute, not per-version/file) |
| `Tags` field on `potentialDownload` | Added | Removed (unnecessary) |
| Tag matching | Manual nested `for` loops | `helpers.StringSliceContains` (consistent with existing patterns) |
| `handleSingleModelDownload` check | Missing | Added early return before processing versions |
| Unit tests | None | 12 table-driven test cases |
| `handleSingleVersionDownload` | Extra API call unconditional | Gated behind `IgnoreTags > 0`, with early return |

## Usage

```bash
# CLI flag
./civitai-downloader download --ignore-tags "nsfw,deprecated"

# config.toml
[Download]
IgnoreTags = ["nsfw", "deprecated"]
```

## Files Changed

- `internal/models/models.go` — `IgnoreTags` field in `DownloadConfig`
- `internal/config/config.go` — Viper defaults, CLI flags, apply logic
- `cmd/civitai-downloader/cmd/download.go` — Flag registration + confirmParameters
- `cmd/civitai-downloader/cmd/debug.go` — Flag in `addDownloadFlags()`
- `cmd/civitai-downloader/cmd/root.go` — Flag application helpers
- `cmd/civitai-downloader/cmd/cmd_download_api.go` — `shouldSkipModelForTags()` + call sites
- `cmd/civitai-downloader/cmd/cmd_download_types.go` — No `Tags` field (simplified)
- `cmd/civitai-downloader/cmd/cmd_download_api_test.go` — 12 unit tests
- `README.md` + `config.toml.example` — Documentation